### PR TITLE
Add library.properties for Arduino Library Registry

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Person Sensor
+version=1.0.0
+author=Useful Sensors
+maintainer=Useful Sensors <support@usefulsensors.com>
+sentence=Library for the Useful Sensors Person Sensor module.
+paragraph=This library provides an interface to the Useful Sensors Person Sensor module, which can detect and recognize faces.
+category=Sensors
+url=https://github.com/usefulsensors/person_sensor_arduino
+architectures=*
+includes=person_sensor.h


### PR DESCRIPTION
Hi, thanks for providing this sensor, and the associated libraries. 
I wanted to make life easier for future arduino users, and add this library to the arduino library registry, but there is a precursor step of adding a library.properties file (this PR), and creating an appropriately tagged release (1.0.0) then someone can add this repo to the list in https://github.com/arduino/library-registry

It might make sense to reorganise the sketch into an examples folder, but I don't think that's crucial (just helpful for IDEs)